### PR TITLE
[Logging] Log to /tmp/wrp.log

### DIFF
--- a/wrp.go
+++ b/wrp.go
@@ -554,6 +554,12 @@ func printIPs(b string) {
 func main() {
 	var err error
 	flag.Parse()
+
+	logfile, err := os.OpenFile("/tmp/wrp.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err == nil {
+		log.SetOutput(logfile)
+	}
+
 	log.Printf("Web Rendering Proxy Version %s\n", version)
 	log.Printf("Args: %q", os.Args)
 	if len(os.Getenv("PORT")) > 0 {


### PR DESCRIPTION
This adds
 - opening `/tmp/wrp.log` in append mode
 - setting the above as output file for `log`


Will improve debugging stuck sessions in `AmiFox`, as well as allow the distributor to collect these from the containers for "is it alive"-checks.

Note: It seems I was able to build the docker locally, but seems I'm to stupid to run it then - it's exits right again. But if I run the `wrp` binary with these changes it works just fine. _What I mean by that is: please test the docker before you merge this._