### PR TITLE
[Security] Slightly improve security by providing an optional authentication requirement

### DIFF
--- a/wrp.go
+++ b/wrp.go
@@ -53,6 +53,7 @@ var (
 	fgeom       = flag.String("g", "1152x600x216", "Geometry: width x height x colors, height can be 0 for unlimited")
 	htmFnam     = flag.String("ui", "wrp.html", "HTML template file for the UI")
 	delay       = flag.Duration("s", 2*time.Second, "Delay/sleep after page is rendered and before screenshot is taken")
+	token       = flag.String("token", "", "If set, all requests need to have this set as Bearer header")
 	srv         http.Server
 	actx, ctx   context.Context
 	acncl, cncl context.CancelFunc
@@ -404,8 +405,29 @@ func (rq *wrpReq) capture() {
 	log.Printf("%s Done with capture for %s\n", rq.r.RemoteAddr, rq.url)
 }
 
+func checkBearerToken(r *http.Request) bool {
+	if *token == "" {
+		return true
+	}
+
+	requestToken := r.Header.Get("Bearer")
+	if requestToken == *token {
+		return true
+	}
+
+	log.Printf("%s Invalid token given in Bearer: '%s' [%+v]\n", r.RemoteAddr, requestToken, r.URL.RawQuery)
+	return false
+}
+
 // Process HTTP requests to WRP '/' url
 func pageServer(w http.ResponseWriter, r *http.Request) {
+	if !checkBearerToken(r) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.(http.Flusher).Flush()
+
+		return
+	}
+
 	log.Printf("%s Page Request for %s [%+v]\n", r.RemoteAddr, r.URL.Path, r.URL.RawQuery)
 	rq := wrpReq{
 		r: r,
@@ -422,6 +444,13 @@ func pageServer(w http.ResponseWriter, r *http.Request) {
 
 // Process HTTP requests to ISMAP '/map/' url
 func mapServer(w http.ResponseWriter, r *http.Request) {
+	if !checkBearerToken(r) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.(http.Flusher).Flush()
+
+		return
+	}
+
 	log.Printf("%s ISMAP Request for %s [%+v]\n", r.RemoteAddr, r.URL.Path, r.URL.RawQuery)
 	rq, ok := ismap[r.URL.Path]
 	rq.r = r
@@ -451,6 +480,13 @@ func mapServer(w http.ResponseWriter, r *http.Request) {
 
 // Process HTTP requests for images '/img/' url
 func imgServer(w http.ResponseWriter, r *http.Request) {
+	if !checkBearerToken(r) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.(http.Flusher).Flush()
+
+		return
+	}
+
 	log.Printf("%s IMG Request for %s\n", r.RemoteAddr, r.URL.Path)
 	imgBuf, ok := img[r.URL.Path]
 	if !ok || imgBuf.Bytes() == nil {
@@ -556,6 +592,11 @@ func main() {
 	flag.Parse()
 	log.Printf("Web Rendering Proxy Version %s\n", version)
 	log.Printf("Args: %q", os.Args)
+	if *token != "" {
+		log.Printf("Authentication configured: %s must be given as Bearer header in all requests", *token)
+	} else {
+		log.Printf("Notice: NO AUTHENTICATION CONFIGURED!")
+	}
 	if len(os.Getenv("PORT")) > 0 {
 		*addr = ":" + os.Getenv(("PORT"))
 	}


### PR DESCRIPTION
- adds '-token' argument, if given all requests require its content given as 'Bearer' header
- adds 401 status return if invalid token is given (in case one is set)
- will log unauthenticated requests

Note: See #1. If I run the wrp binary with these changes it works just fine. But please test the docker before you merge this.

```
make wrp && ./wrp -token bla
go build wrp.go
2023/02/19 18:51:23 Web Rendering Proxy Version 4.6.0
2023/02/19 18:51:23 Args: ["./wrp" "-token" "bla"]
2023/02/19 18:51:23 Authentication configured: bla must be given as Bearer header in all requests
2023/02/19 18:51:23 Listen address: :8080
2023/02/19 18:51:23 My IP addresses: 192.168.1.101 172.28.0.1 172.20.0.1 172.24.0.1 172.18.0.1 172.17.0.1 
2023/02/19 18:51:23 Default Img Type: gif, Geometry: {w:1152 h:600 c:216}
2023/02/19 18:51:23 Got HTML UI template from wrp.html file, size 3228 
2023/02/19 18:51:23 Starting WRP http server
2023/02/19 18:51:26 127.0.0.1:52268 Invalid token given in Bearer: '' []
2023/02/19 18:51:32 127.0.0.1:52268 Page Request for / []
2023/02/19 18:51:32 127.0.0.1:52268 WrpReq from UI Form: &{url: width:1152 height:600 zoom:1 colors:216 mouseX:0 mouseY:0 keys: buttons: imgType:gif title: w:0xc00021e000 r:0xc000124000}
^C2023/02/19 18:55:04 Interrupt - shutting down.
2023/02/19 18:55:04 http: Server closed
```