### PR TITLE
WIP: [Bandwidth] Add optipng and jpegoptim to improve bandwidth usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
 FROM chromedp/headless-shell
+
+# Install image optimization tools
+RUN apt-get -y update --fix-missing && \
+    apt-get upgrade -y && \
+    apt-get --no-install-recommends install -y optipng jpegoptim && \
+    rm -rf /var/lib/apt/lists/*
+
 ADD wrp /wrp
 ENTRYPOINT ["/wrp"]
 ENV PATH="/headless-shell:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM chromedp/headless-shell
 # Install image optimization tools
 RUN apt-get -y update --fix-missing && \
     apt-get upgrade -y && \
-    apt-get --no-install-recommends install -y optipng jpegoptim && \
+    apt-get --no-install-recommends install -y optipng jpegoptim gifsicle && \
     rm -rf /var/lib/apt/lists/*
 
 ADD wrp /wrp

--- a/wrp.go
+++ b/wrp.go
@@ -596,6 +596,13 @@ func optimizeImageFile(imgPath string, colors int64, buffer bytes.Buffer) []byte
 	}
 
 	log.Printf("Optimized image, new filesize: %d KB", size)
+	defer func(name string) {
+		err := os.Remove(name)
+		if err != nil {
+			log.Printf("Can't unlink tmp file")
+		}
+	}(tmpFileName)
+
 	return b
 }
 

--- a/wrp.go
+++ b/wrp.go
@@ -54,6 +54,7 @@ var (
 	fgeom       = flag.String("g", "1152x600x216", "Geometry: width x height x colors, height can be 0 for unlimited")
 	htmFnam     = flag.String("ui", "wrp.html", "HTML template file for the UI")
 	delay       = flag.Duration("s", 2*time.Second, "Delay/sleep after page is rendered and before screenshot is taken")
+	imgOpti     = flag.Bool("O", false, "Optimize images with external tools (optipng, jpegoptim)")
 	srv         http.Server
 	actx, ctx   context.Context
 	acncl, cncl context.CancelFunc
@@ -394,7 +395,10 @@ func (rq *wrpReq) capture() {
 		log.Printf("%s Encoded JPG image: %s, Size: %s, Quality: %d, Res: %dx%d, Time: %vms\n", rq.r.RemoteAddr, imgPath, sSize, *jpgQual, iW, iH, time.Since(st).Milliseconds())
 	}
 
-	img[imgPath] = *bytes.NewBuffer(optimizeImageFile(imgPath, rq.colors, img[imgPath]))
+	if *imgOpti {
+		img[imgPath] = *bytes.NewBuffer(optimizeImageFile(imgPath, rq.colors, img[imgPath]))
+	}
+
 	rq.printHTML(printParams{
 		bgColor:    fmt.Sprintf("#%02X%02X%02X", r, g, b),
 		pageHeight: fmt.Sprintf("%d PX", h),


### PR DESCRIPTION
Experimental PR to add image optimization. Needs flag `-O` given to be enabled.

For PNG this already reduces resulting image size quite noticeable. For JPG is barely noticeable and almost in the area of "float losses" :D. For GIF it currently even increases the filesize at times. I guess the custom palette stuff is already all optimization you can do on it.

Examples: 
```
2023/02/23 17:16:26 127.0.0.1:40380 Encoded JPG image: /img/7675.jpg, Size: 225 KB, Quality: 80, Res: 1152x2000, Time: 61ms
2023/02/23 17:16:26 Optimized image, new filesize: 224 KB
2023/02/23 17:15:48 127.0.0.1:40380 Got PNG image: /img/2319.png, Size: 506 KB, Res: 1152x2000
2023/02/23 17:15:50 Optimized image, new filesize: 440 KB
2023/02/23 17:12:34 127.0.0.1:51662 Encoded JPG image: /img/5302.jpg, Size: 43 KB, Quality: 80, Res: 1152x600, Time: 17ms
2023/02/23 17:12:34 Optimized image, new filesize: 42 KB
2023/02/23 17:12:30 127.0.0.1:51662 Encoded JPG image: /img/3795.jpg, Size: 135 KB, Quality: 80, Res: 1152x600, Time: 20ms
2023/02/23 17:12:30 Optimized image, new filesize: 134 KB
2023/02/23 17:12:16 127.0.0.1:51662 Encoded JPG image: /img/4935.jpg, Size: 105 KB, Quality: 80, Res: 1152x600, Time: 21ms
2023/02/23 17:12:16 Optimized image, new filesize: 104 KB
2023/02/23 16:52:40 127.0.0.1:36926 Got PNG image: /img/8439.png, Size: 154 KB, Res: 1152x600
2023/02/23 16:52:40 Optimized image, new filesize: 108 KB
2023/02/23 16:51:14 127.0.0.1:39386 Got PNG image: /img/7068.png, Size: 152 KB, Res: 1152x600
2023/02/23 16:51:15 Optimized image, new filesize: 110070
```

Executable works fine on my machine, but as last time: docker run issues. Again builds successful though