### PR TITLE
Feature: Add support for specifing 'Accept-Language' http request header for visited sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ $ docker run -d -p 80:8080 alb42/amifoxserver
 -ua  user agent, override the default "headless" agent
 -s     delay/sleep after page is rendered before screenshot is taken (default 2s)
 -token If set, all requests need to have this set as Bearer header
+-log If set, logging will be redirected to given file
+-lang If set, given value will be passed as 'Accept-Language' header to visited sites
 ```
 
 ## Minimal Requirements

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ $ docker run -d -p 80:8080 alb42/amifoxserver
 -s     delay/sleep after page is rendered before screenshot is taken (default 2s)
 -token If set, all requests need to have this set as Bearer header
 -log If set, logging will be redirected to given file
--lang If set, given value will be passed as 'Accept-Language' header to visited sites
 ```
 
 ## Minimal Requirements

--- a/wrp.html
+++ b/wrp.html
@@ -10,6 +10,7 @@
             <INPUT TYPE="SUBMIT" NAME="Fn" VALUE="Fw">
             <INPUT TYPE="SUBMIT" NAME="Fn" VALUE="St">
             <INPUT TYPE="SUBMIT" NAME="Fn" VALUE="Re">
+            LANG <INPUT TYPE="TEXT" NAME="lang" VALUE="{{.Lang}}" SIZE="12">
             W <INPUT TYPE="TEXT" NAME="w" VALUE="{{.Width}}" SIZE="4">
             H <INPUT TYPE="TEXT" NAME="h" VALUE="{{.Height}}" SIZE="4">
             Z <SELECT NAME="z">


### PR DESCRIPTION
- new flag `-lang` added, given value will be set as `Accept-Language` in chromedp
- updated version and readme

Note: distributor does not support an option for it yet, to be done