### PR TITLE
Fix: Search for stuff not like a URL uses HTTP

### DIFF
--- a/wrp.go
+++ b/wrp.go
@@ -148,7 +148,7 @@ func (rq *wrpReq) parseForm() {
 	rq.r.ParseForm()
 	rq.url = rq.r.FormValue("url")
 	if len(rq.url) > 1 && !strings.HasPrefix(rq.url, "http") {
-		rq.url = fmt.Sprintf("http://www.google.com/search?q=%s", url.QueryEscape(rq.url))
+		rq.url = fmt.Sprintf("https://www.google.com/search?q=%s", url.QueryEscape(rq.url))
 	}
 	rq.width, _ = strconv.ParseInt(rq.r.FormValue("w"), 10, 64)
 	rq.height, _ = strconv.ParseInt(rq.r.FormValue("h"), 10, 64)


### PR DESCRIPTION
Currently the "user input doesnt look like a url so lets search" uses http, for one this is bad practive but for 2nd this will just be redirected by google to https anyway.

This avoids the redirect (even if a tiny micro-optimization :laughing: )